### PR TITLE
Add bulk database perations

### DIFF
--- a/Database/DatabaseAccess.cs
+++ b/Database/DatabaseAccess.cs
@@ -87,13 +87,13 @@ namespace GilGoblin.Database
                 int saves = 0;
                 foreach (MarketDataDB marketData in marketDataList ?? Enumerable.Empty<MarketDataDB>())
                 {
-                    saves += await SaveMarketData(marketData);
+                    saves += await SaveMarketDataSingle(marketData);
                 }
                 return saves;
             }
         }
 
-        internal static async Task<int> SaveMarketData(MarketDataDB marketData)
+        internal static async Task<int> SaveMarketDataSingle(MarketDataDB marketData)
         {
             try
             {

--- a/Database/MarketDataDB.cs
+++ b/Database/MarketDataDB.cs
@@ -1,5 +1,6 @@
 ﻿using GilGoblin.Finance;
 using GilGoblin.WebAPI;
+using System;
 using System.Collections.Generic;
 
 namespace GilGoblin.Database
@@ -24,7 +25,8 @@ namespace GilGoblin.Database
             {
                 listings.Add(web.ConvertToDB());
             }
-            this.last_updated = data.last_updated;
+            //this.last_updated = data.last_updated;
+            this.last_updated = DateTime.Now;
             this.average_price = data.average_price;
             this.item_id = data.item_id;
             this.world_id = data.world_id;

--- a/Database/MarketDataDB.cs
+++ b/Database/MarketDataDB.cs
@@ -25,7 +25,7 @@ namespace GilGoblin.Database
                 listings.Add(web.ConvertToDB());
             }
             this.last_updated = data.last_updated;
-            this.average_Price = data.average_Price;
+            this.average_price = data.average_price;
             this.item_id = data.item_id;
             this.world_id = data.world_id;
 

--- a/Finance/ItemInfo.cs
+++ b/Finance/ItemInfo.cs
@@ -24,13 +24,13 @@ namespace GilGoblin.WebAPI
         /// <param name="description">In-game text description</param>
         /// <param name="vendor_price">Price for selling to vendor</param>
         /// <param name="current_listings">Optional: current listings on the marketboard</param>
-        public ItemInfo(int itemID, string name, int priceMid, int stackSize, List<APIRecipe> recipes)
+        public ItemInfo(int itemID, string name, int priceMid, int stackSize, int gatheringID, List<APIRecipe> recipes)
         {
             this.item_id = itemID;
             this.description = name;
             this.vendor_price = priceMid;
             this.stack_size = stackSize;
-            //this.gathering_item = 
+            this.gathering_id = gatheringID;
             this.recipes = recipes;
         }
     }

--- a/Finance/MarketData.cs
+++ b/Finance/MarketData.cs
@@ -51,21 +51,19 @@ namespace GilGoblin.Finance
         /// </summary>
         /// <param name="dict"></param>A Dictionary<int,int> that represents the item_id and world_id
         /// <returns></returns>
-        internal static List<MarketDataDB> GetMarketDataBulk(Dictionary<int, int> dict)
+        internal static List<MarketDataDB> GetMarketDataBulk(List<int> itemIDs, int world_ID)
         {
-            if (dict == null || dict.Count == 0)
+            if (world_ID == 0 || itemIDs == null || itemIDs.Count == 0)
             {
-                Console.WriteLine("Trying to get an empty dictionary of market data.");
+                Console.WriteLine("Trying to get bulk market data with missing parameters.");
                 return null;
             }
             else
             {
-                List<MarketDataDB> list = new List<MarketDataDB>();
-                foreach (KeyValuePair<int, int> item_world in dict)
-                {
-                    list.Add(GetMarketData(item_world.Key, item_world.Value));
-                }
-                return list;
+                List<MarketDataDB> listDB = new List<MarketDataDB>();
+                List<MarketDataWeb> listWeb = new List<MarketDataWeb>();
+                listWeb = MarketDataWeb.FetchMarketDataBulk(itemIDs, world_ID).GetAwaiter().GetResult();   
+                return listDB;
             }
         }
 
@@ -118,6 +116,16 @@ namespace GilGoblin.Finance
             return average_Price;
         }
     }
+
+    internal class MarketDataBulk
+    {
+        ICollection<MarketData> bulkData = new List<MarketData>();
+
+        MarketDataBulk()
+        {
+        }
+    }
+
 }
 
 

--- a/Finance/MarketData.cs
+++ b/Finance/MarketData.cs
@@ -13,7 +13,7 @@ namespace GilGoblin.Finance
         public int item_id { get; set; }
         public int world_id { get; set; }
         public DateTime last_updated { get; set; }
-        public int average_Price { get; set; }
+        public int average_price { get; set; }
 
         public static int _staleness_hours_for_refresh = 2; //todo: increase for production
 
@@ -45,9 +45,8 @@ namespace GilGoblin.Finance
         }
 
         /// <summary>
-        /// Given a Dictionary<int,int> that represents the item_id and world_id
-        /// respectively, get the market data for each and return it as a List
-        /// This can be re-written more efficiently later if performance becomes an issue
+        /// Given a List<int> that represents the item_id, along with the world_id,
+        /// get the market data for each item and return it as a List
         /// </summary>
         /// <param name="dict"></param>A Dictionary<int,int> that represents the item_id and world_id
         /// <returns></returns>
@@ -60,17 +59,85 @@ namespace GilGoblin.Finance
             }
             else
             {
+                List<MarketDataDB> listReturn = new List<MarketDataDB>();
                 List<MarketDataDB> listDB = new List<MarketDataDB>();
-                List<MarketDataWeb> listWeb = MarketDataWeb.FetchMarketDataBulk(itemIDs, world_ID).GetAwaiter().GetResult();
+                //Does it exist in the database? Is it stale?
+                try
+                {
+                    listDB = DatabaseAccess.GetMarketDataDBBulk(itemIDs, world_ID);
+                }
+                catch (Exception ex)
+                {
+                    // Error and/or not found in the database
+                    Console.WriteLine(ex.Message);
+                }
+
+                //Trim the list of entries back from the database
+                //Return the ones that need to be fetched
+                //This should included stale data & ones new to the database
+                List<MarketDataDB> freshDataDB = filterFreshData(listDB);
+                List<int> itemIDFetchList = itemIDs;
+                foreach (MarketDataDB success in freshDataDB)
+                {
+                    listReturn.Add(success);
+                    itemIDFetchList.Remove(success.item_id);                    
+                }
+
+                List<MarketDataWeb> listWeb = new List<MarketDataWeb>();
+                if (itemIDFetchList.Count == 1)
+                {
+                    int fetchSingle = (int)itemIDFetchList[0];
+                    listWeb.Add(MarketDataWeb.FetchMarketData(fetchSingle, world_ID)
+                        .GetAwaiter().GetResult());
+                }
+                if (itemIDFetchList.Count > 1)
+                {
+                    listWeb = MarketDataWeb.FetchMarketDataBulk(itemIDFetchList, world_ID).GetAwaiter().GetResult();
+                }
                 if (listWeb != null)
                 {
                     foreach (MarketDataWeb web in listWeb)
                     {
-                        listDB.Add(new MarketDataDB(web));
+                        listReturn.Add(new MarketDataDB(web));
                     }
                 }
-                return listDB;
+                return listReturn;
             }
+        }
+
+        public static List<MarketDataDB> filterFreshData(List<MarketDataDB> list)
+        {
+            List<MarketDataDB> fresh = new List<MarketDataDB>();
+            foreach (MarketDataDB dataDB in list)
+            {
+                if (!isDataStale(dataDB))
+                {
+                    fresh.Add(dataDB);
+                }
+                else { //do nothing?
+                //{
+                //    dataDB.last_updated = DateTime.Now;
+                //    dataDB.average_Price = marketData.average_Price;
+                //    dataDB.listings = marketData.listings;
+                //    marketDataContext.Update<MarketDataDB>(exists);
+                }
+            }
+            return fresh;
+
+        }
+
+        /// <summary>
+        /// Verifies if the data is too stale/old
+        /// </summary>
+        /// <param name="marketData"></param>The object of market data in DB format
+        /// <returns></returns>
+        public static bool isDataStale(MarketDataDB marketData)
+        {
+            //Check for freshness: if old, update data
+            TimeSpan diff = DateTime.Now - marketData.last_updated;
+            double hoursElapsed = diff.TotalHours;
+            if (hoursElapsed > MarketData._staleness_hours_for_refresh) { return true; }
+            else { return false; }
         }
 
         public static ItemInfo GetItemInfo(int item_id)

--- a/Finance/MarketData.cs
+++ b/Finance/MarketData.cs
@@ -75,12 +75,13 @@ namespace GilGoblin.Finance
                 //Trim the list of entries back from the database
                 //Return the ones that need to be fetched
                 //This should included stale data & ones new to the database
-                List<MarketDataDB> freshDataDB = filterFreshData(listDB);
+                List<MarketDataDB> freshDataDB = new List<MarketDataDB>();
+                freshDataDB = filterFreshData(listDB);
                 List<int> itemIDFetchList = itemIDs;
                 foreach (MarketDataDB success in freshDataDB)
                 {
                     listReturn.Add(success);
-                    itemIDFetchList.Remove(success.item_id);                    
+                    itemIDFetchList.Remove(success.item_id);
                 }
 
                 List<MarketDataWeb> listWeb = new List<MarketDataWeb>();
@@ -108,18 +109,15 @@ namespace GilGoblin.Finance
         public static List<MarketDataDB> filterFreshData(List<MarketDataDB> list)
         {
             List<MarketDataDB> fresh = new List<MarketDataDB>();
-            foreach (MarketDataDB dataDB in list)
+            if (list != null)
             {
-                if (!isDataStale(dataDB))
+                foreach (MarketDataDB dataDB in list)
                 {
-                    fresh.Add(dataDB);
-                }
-                else { //do nothing?
-                //{
-                //    dataDB.last_updated = DateTime.Now;
-                //    dataDB.average_Price = marketData.average_Price;
-                //    dataDB.listings = marketData.listings;
-                //    marketDataContext.Update<MarketDataDB>(exists);
+                    if (!isDataStale(dataDB))
+                    {
+                        fresh.Add(dataDB);
+                    }
+                    else { } //do nothing                       
                 }
             }
             return fresh;

--- a/Finance/MarketData.cs
+++ b/Finance/MarketData.cs
@@ -61,8 +61,14 @@ namespace GilGoblin.Finance
             else
             {
                 List<MarketDataDB> listDB = new List<MarketDataDB>();
-                List<MarketDataWeb> listWeb = new List<MarketDataWeb>();
-                listWeb = MarketDataWeb.FetchMarketDataBulk(itemIDs, world_ID).GetAwaiter().GetResult();   
+                List<MarketDataWeb> listWeb = MarketDataWeb.FetchMarketDataBulk(itemIDs, world_ID).GetAwaiter().GetResult();
+                if (listWeb != null)
+                {
+                    foreach (MarketDataWeb web in listWeb)
+                    {
+                        listDB.Add(new MarketDataDB(web));
+                    }
+                }
                 return listDB;
             }
         }

--- a/Functions/Exceptions.cs
+++ b/Functions/Exceptions.cs
@@ -13,4 +13,15 @@ namespace GilGoblin.Functions
         public DBStatusException(string message, Exception inner)
             : base(message, inner) { }
     }
+    [Serializable]
+    public class ParameterException : Exception
+    {
+        public ParameterException() { }
+
+        public ParameterException(string message)
+            : base(message) { }
+
+        public ParameterException(string message, Exception inner)
+            : base(message, inner) { }
+    }
 }

--- a/Functions/General_Function.cs
+++ b/Functions/General_Function.cs
@@ -20,7 +20,9 @@ namespace GilGoblin.Functions
 
         public static DateTime ConvertLongUnixMillisecondsToDateTime(long elapsed_time)
         {
-            return ConvertLongUnixSecondsToDateTime(elapsed_time / 1000);
+            DateTime date
+                = DateTimeOffset.FromUnixTimeMilliseconds(elapsed_time).LocalDateTime;
+            return date;
         }
 
         public static DateTime ConvertLongFromBinaryToDateTime(long elapsed_time)

--- a/Tests/Dev_Tests.cs
+++ b/Tests/Dev_Tests.cs
@@ -27,7 +27,7 @@ namespace GilGoblin.Tests
                 {
                     throw new Exception("Market data or item info not found");
                 }
-                int marketPrice = marketData.average_Price;
+                int marketPrice = marketData.average_price;
                 Console.WriteLine("Final market price: " + marketPrice);
                 int vendorPrice = itemInfo.vendor_price;
                 Console.WriteLine("Vendor price: " + vendorPrice);

--- a/Tests/Dev_Tests.cs
+++ b/Tests/Dev_Tests.cs
@@ -35,7 +35,7 @@ namespace GilGoblin.Tests
                 Console.WriteLine("Estimated profit: " + profit);
 
                 string success_message = "failure.";
-                int db_success = await DatabaseAccess.SaveMarketData(marketData);
+                int db_success = await DatabaseAccess.SaveMarketDataSingle(marketData);
                 if (db_success > 0) { success_message = "sucess."; }
                 Console.WriteLine("Database save was a " + success_message);
 
@@ -57,12 +57,10 @@ namespace GilGoblin.Tests
         {
             try
             {
-                Dictionary<int, int> fetchList = new Dictionary<int, int>();
+                List<int> fetchIDList = new List<int> { item_id, 5114, 5106 };
                 List<ItemInfo> infoList = new List<ItemInfo>();
-                fetchList.Add(item_id, world_id);
-                fetchList.Add(5114, world_id);
-                fetchList.Add(5106, world_id);
-                List<MarketDataDB> marketDataList = MarketData.GetMarketDataBulk(fetchList);
+                List<MarketDataDB> marketDataList 
+                    = MarketData.GetMarketDataBulk(fetchIDList, world_id);
                 foreach (MarketDataDB dataDb in marketDataList)
                 {
                     infoList.Add(MarketData.GetItemInfo(item_id));

--- a/WebAPI/MarketDataWeb.cs
+++ b/WebAPI/MarketDataWeb.cs
@@ -73,10 +73,11 @@ namespace GilGoblin.WebAPI
             }
         }
 
-        public static async Task<MarketDataWebBulk> FetchMarketDataBulk(List<int> itemIDs, int world_id)
+        public static async Task<List<MarketDataWeb>> FetchMarketDataBulk(List<int> itemIDs, int world_id)
         {
             try
             {
+                List<MarketDataWeb> list = new List<MarketDataWeb>();
                 HttpClient client = new HttpClient();
                 //https://universalis.app/api/34/5114%2C5106%2C5057
                 string url = String.Concat("https://universalis.app/api/", world_id, "/");
@@ -88,7 +89,10 @@ namespace GilGoblin.WebAPI
 
                 //Deserialize from JSON to the object
                 MarketDataWebBulk bulkData = JsonConvert.DeserializeObject<MarketDataWebBulk>(json);
-                return bulkData;
+                if (bulkData != null) { 
+                    list = bulkData.items; 
+                }
+                return list;
             }
             catch (Exception ex)
             {

--- a/WebAPI/MarketDataWeb.cs
+++ b/WebAPI/MarketDataWeb.cs
@@ -20,14 +20,14 @@ namespace GilGoblin.WebAPI
 
         public int getPrice(bool update = false)
         {
-            if (update || average_Price == 0)
+            if (update || average_price == 0)
             {
                 //Re-calculate the price and update
                 CalculateAveragePrice(listings);
             }
 
             //Return what we do have regardless of updates
-            return average_Price;
+            return average_price;
         }
 
         [JsonConstructor]
@@ -51,7 +51,7 @@ namespace GilGoblin.WebAPI
                 listing.world_id = worldId;
             }
 
-            this.average_Price = CalculateAveragePrice(this.listings);
+            this.average_price = CalculateAveragePrice(this.listings);
         }
 
         public static async Task<MarketDataWeb> FetchMarketData(int item_id, int world_id)
@@ -59,7 +59,7 @@ namespace GilGoblin.WebAPI
             try
             {
                 HttpClient client = new HttpClient();
-                string url = "https://universalis.app/api/history/" + world_id + "/" + item_id;
+                string url = "https://universalis.app/api/" + world_id + "/" + item_id;
                 var content = await client.GetAsync(url);
 
                 //Deserialize from JSON to the object

--- a/WebAPI/MarketListingWeb.cs
+++ b/WebAPI/MarketListingWeb.cs
@@ -22,8 +22,15 @@ namespace GilGoblin.WebAPI
             this.price = pricePerUnit;
             this.qty = quantity;
             this.hq = hq;
-            //this.timestamp = General_Function.ConvertLongUnixSecondsToDateTime(timestamp);
-            this.timestamp = General_Function.ConvertLongUnixMillisecondsToDateTime(timestamp);
+            if (timestamp.Equals(0))
+            {
+
+            }
+            else
+            {
+                this.timestamp = General_Function.ConvertLongUnixSecondsToDateTime(timestamp);
+            }
+
         }
 
         public MarketListingDB ConvertToDB()

--- a/WebAPI/MarketListingWeb.cs
+++ b/WebAPI/MarketListingWeb.cs
@@ -22,7 +22,8 @@ namespace GilGoblin.WebAPI
             this.price = pricePerUnit;
             this.qty = quantity;
             this.hq = hq;
-            this.timestamp = General_Function.ConvertLongUnixSecondsToDateTime(timestamp);
+            //this.timestamp = General_Function.ConvertLongUnixSecondsToDateTime(timestamp);
+            this.timestamp = General_Function.ConvertLongUnixMillisecondsToDateTime(timestamp);
         }
 
         public MarketListingDB ConvertToDB()


### PR DESCRIPTION
Converts the existing singular operations to the database to bulk operations. These are internally defined as:

1. Get (gets from database)
2. Fetch (fetch from the web using an API)
3. Save (saves the updated data: insert/update as necessary)

These were tested using 3 items.