### PR TITLE
Fix pipeline to only publish on merge to master

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -103,4 +103,3 @@ jobs:
               echo "No Dockerfile found in $project_dir, skipping..."
             fi
           done
-          

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,10 +1,9 @@
 name: Post-Merge Workflow
 
 on:
-  workflow_run:
-    workflows: ["ci"]
-    types:
-      - completed
+  push:
+    branches:
+      - master
 
 jobs:
   publish-nuget:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -103,3 +103,4 @@ jobs:
               echo "No Dockerfile found in $project_dir, skipping..."
             fi
           done
+          


### PR DESCRIPTION
Should only publish docker images & nuget packages when merging to the `master` branch